### PR TITLE
Refactor builder function to return mutable references

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,7 @@ impl<const N: usize> Poisson<N> {
     /// # use fast_poisson::Poisson2D;
     /// let points = Poisson2D::new().with_seed(0xBADBEEF).iter();
     /// ```
-    pub fn with_seed(&mut self, seed: u64) -> &Self {
+    pub fn with_seed(&mut self, seed: u64) -> &mut Self {
         self.seed = Some(seed);
 
         self
@@ -270,7 +270,7 @@ impl<const N: usize> Poisson<N> {
     /// # use fast_poisson::Poisson3D;
     /// let points = Poisson3D::new().with_samples(40).iter();
     /// ```
-    pub fn with_samples(&mut self, samples: u32) -> &Self {
+    pub fn with_samples(&mut self, samples: u32) -> &mut Self {
         self.num_samples = samples;
 
         self


### PR DESCRIPTION
Currently, you can not use the builder pattern to create
```rust
let points = PoissonVariable2D::new()
        .with_dimensions([10.0, 10.0], 2.0)
        .with_seed(123123)
        .with_samples(30)
        .generate();
```
because only the with_dimensions function returns a mutable reference. This PR makes all the builder functions return mutable references so they can be chained in any order.