### PR TITLE
33 some points are closer than expected

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = ["/.github/*"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+kiddo = "2.0.1"
 rand = "0.8.4"
 rand_xoshiro = "0.6.0"
 rand_distr = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ derive_serde = ["serde", "serde_arrays"]
 
 [dev-dependencies]
 serde_json = "1.0"
+rayon = "1.7"

--- a/src/iter/tests.rs
+++ b/src/iter/tests.rs
@@ -9,137 +9,6 @@ use super::*;
 use crate::{Poisson2D, Poisson3D};
 
 #[test]
-fn cell_size() {
-    let poisson1 = Poisson::<1>::new().with_dimensions([1.0], 0.1).iter();
-    let poisson2 = Poisson::<2>::new().with_dimensions([1.0; 2], 0.1).iter();
-    let poisson3 = Poisson::<3>::new().with_dimensions([1.0; 3], 0.1).iter();
-    let poisson4 = Poisson::<4>::new().with_dimensions([1.0; 4], 0.1).iter();
-
-    {
-        // This "useless conversion" ensures our test runs properly whether we're
-        // using f64 or f32 per our Cargo features selection
-        #![allow(clippy::useless_conversion)]
-
-        assert_eq!(poisson1.cell_size, 0.1 / Float::from(1.0).sqrt());
-        assert_eq!(poisson2.cell_size, 0.1 / Float::from(2.0).sqrt());
-        assert_eq!(poisson3.cell_size, 0.1 / Float::from(3.0).sqrt());
-        assert_eq!(poisson4.cell_size, 0.1 / Float::from(4.0).sqrt());
-    }
-}
-
-#[test]
-fn n_dimensional_grid_size() {
-    for n in 1..=3 {
-        let mut poisson0 = Poisson::<0>::new();
-        let mut poisson1 = Poisson::<1>::new();
-        let mut poisson2 = Poisson::<2>::new();
-        let mut poisson3 = Poisson::<3>::new();
-        let mut poisson4 = Poisson::<4>::new();
-
-        poisson0.dimensions = [];
-        poisson1.dimensions = [n as Float];
-        poisson2.dimensions = [n as Float; 2];
-        poisson3.dimensions = [n as Float; 3];
-        poisson4.dimensions = [n as Float; 4];
-
-        let iter0 = poisson0.iter();
-        let iter1 = poisson1.iter();
-        let iter2 = poisson2.iter();
-        let iter3 = poisson3.iter();
-        let iter4 = poisson4.iter();
-
-        assert_eq!(iter0.grid.len(), 1);
-        assert_eq!(
-            iter1.grid.len(),
-            (n as Float / iter1.cell_size).ceil() as usize
-        );
-        assert_eq!(
-            iter2.grid.len(),
-            ((n as Float / iter2.cell_size).ceil() as usize).pow(2)
-        );
-        assert_eq!(
-            iter3.grid.len(),
-            ((n as Float / iter3.cell_size).ceil() as usize).pow(3)
-        );
-        assert_eq!(
-            iter4.grid.len(),
-            ((n as Float / iter4.cell_size).ceil() as usize).pow(4)
-        );
-    }
-}
-
-#[test]
-fn n_dimensional_cell_to_idx() {
-    let poisson = Poisson::<3> {
-        dimensions: [3., 3., 3.],
-        ..Default::default()
-    };
-    let mut iter = poisson.iter();
-    // Coerce cell_size to more easily test cell_to_idx function
-    iter.cell_size = 1.;
-
-    assert_eq!(iter.cell_to_idx([0, 0, 0]), 0);
-    assert_eq!(iter.cell_to_idx([1, 1, 1]), 13);
-    assert_eq!(iter.cell_to_idx([1, 2, 1]), 16);
-    assert_eq!(iter.cell_to_idx([2, 1, 1]), 22);
-
-    let poisson = Poisson::<2> {
-        dimensions: [3., 3.],
-        ..Default::default()
-    };
-    let mut iter = poisson.iter();
-    // Coerce cell_size to more easily test cell_to_idx function
-    iter.cell_size = 1.;
-
-    assert_eq!(iter.cell_to_idx([0, 0]), 0);
-    assert_eq!(iter.cell_to_idx([1, 1]), 4);
-    assert_eq!(iter.cell_to_idx([1, 2]), 5);
-    assert_eq!(iter.cell_to_idx([2, 1]), 7);
-}
-
-#[test]
-fn n_dimensional_point_to_cell() {
-    let poisson = Poisson::<3> {
-        dimensions: [3., 3., 3.],
-        ..Default::default()
-    };
-    let mut iter = poisson.iter();
-    // Coerce cell_size to more easily test point_to_cell function
-    iter.cell_size = 2.;
-
-    assert_eq!(iter.point_to_cell([0., 0., 0.]), [0, 0, 0]);
-    assert_eq!(iter.point_to_cell([1., 1., 1.]), [0, 0, 0]);
-    assert_eq!(iter.point_to_cell([1., 2., 1.]), [0, 1, 0]);
-    assert_eq!(iter.point_to_cell([2., 3., 1.]), [1, 1, 0]);
-
-    let poisson = Poisson::<2> {
-        dimensions: [3., 3.],
-        ..Default::default()
-    };
-    let mut iter = poisson.iter();
-    // Coerce cell_size to more easily test point_to_cell function
-    iter.cell_size = 2.;
-
-    assert_eq!(iter.point_to_cell([0., 0.]), [0, 0]);
-    assert_eq!(iter.point_to_cell([1., 1.]), [0, 0]);
-    assert_eq!(iter.point_to_cell([1., 2.]), [0, 1]);
-    assert_eq!(iter.point_to_cell([2., 3.]), [1, 1]);
-}
-
-#[test]
-fn sample_to_grid() {
-    let iter = Poisson::<2>::new().iter();
-
-    for &point in &[[0.0, 0.0], [0.5, 0.5], [1.0, 1.0]] {
-        let idx = iter.point_to_idx(point);
-
-        // Trying to access this will panic if it's out of bound in any way
-        // TODO: #25 Should do more robust testing of the results
-        let _ = iter.grid[idx];
-    }
-}
-
-#[test]
 fn adding_points() {
     let mut iter = Poisson::<2>::new().iter();
     let point = [0.5, 0.5];
@@ -148,8 +17,7 @@ fn adding_points() {
 
     assert!(iter.active.contains(&point));
 
-    let idx = iter.point_to_idx(point);
-    assert_eq!(iter.grid[idx], Some(point));
+    assert_eq!(iter.sampled.nearest_one(&point, &squared_euclidean), (0.0, 0));
 }
 
 #[test]
@@ -218,21 +86,10 @@ fn in_space() {
 }
 
 #[test]
-fn empty_grid_has_no_neighbors() {
-    let mut iter = Poisson::<2>::new().iter();
-    // Flush the grid
-    iter.grid = vec![None; iter.grid.len()];
-
-    assert!(!iter.in_neighborhood([0.1, 0.1]));
-    assert!(!iter.in_neighborhood([0.2, 0.2]));
-    assert!(!iter.in_neighborhood([1.1, 1.1])); // Out of bounds by definition has no neighbors
-}
-
-#[test]
 fn distant_point_has_no_neighbors() {
     let mut iter = Poisson::<2>::new().iter();
-    // Flush the grid
-    iter.grid = vec![None; iter.grid.len()];
+    // Flush the k-d tree
+    iter.sampled = KdTree::new();
 
     // Add test point
     iter.add_point([0.9, 0.9]);
@@ -245,26 +102,12 @@ fn distant_point_has_no_neighbors() {
 #[test]
 fn point_has_neighbors() {
     let mut iter = Poisson::<2>::new().iter();
-    // Flush the grid
-    iter.grid = vec![None; iter.grid.len()];
+    // Flush the k-d tree
+    iter.sampled = KdTree::new();
 
     // Add test point
     iter.add_point([0.2, 0.2]);
 
     assert!(iter.in_neighborhood([0.2, 0.2])); // Same point is a neighbor
     assert!(iter.in_neighborhood([0.2005, 0.2])); // Close point is a neighbor
-}
-
-#[test]
-fn out_of_bounds_point_is_not_neighbor() {
-    let mut iter = Poisson::<2>::new().iter();
-    // Flush the grid
-    iter.grid = vec![None; iter.grid.len()];
-
-    // Enlarge radius
-    iter.distribution.radius = 0.5;
-    // Add test point near perimeter
-    iter.add_point([0.9, 0.9]);
-
-    assert!(!iter.in_neighborhood([1.1, 1.1])); // Out of bounds by definition has no neighbors
 }

--- a/tests/closeness.rs
+++ b/tests/closeness.rs
@@ -1,0 +1,26 @@
+use fast_poisson::Poisson2D;
+
+/// Ensure points remain at minimum radius apart
+///
+/// Ref #33
+#[test]
+fn closeness() {
+    let seed: u64 = 6980462275800279379;
+
+    let points = Poisson2D::new()
+        .with_dimensions([30.0, 20.0], 5.0)
+        .with_seed(seed)
+        .generate();
+
+    // Test every point against every other point
+    for i in 0..(points.len() - 1) {
+        // Only need to test points later in the list, since we've already tested i against earlier points
+        for j in (i+1)..points.len() {
+            assert!(5.0 <= distance(points[i], points[j]));
+        }
+    }
+}
+
+fn distance(p1: [f64; 2], p2: [f64; 2]) -> f64 {
+    ((p1[0] - p2[0]).powi(2) + (p1[1] - p2[1]).powi(2)).sqrt()
+}

--- a/tests/closeness.rs
+++ b/tests/closeness.rs
@@ -1,4 +1,5 @@
 use fast_poisson::Poisson2D;
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
 /// Ensure points remain at minimum radius apart
 ///
@@ -19,6 +20,31 @@ fn closeness() {
             assert!(5.0 <= distance(points[i], points[j]));
         }
     }
+}
+
+/// Thoroughly ensure points remain at minimum radius apart
+///
+/// Ref #33
+#[test]
+#[ignore = "This test checks 1 million seeds in parallel to ensure minimum distance guarantees are maintained"]
+fn closeness_thorough() {
+    (0..1_000_000).into_par_iter().for_each(|seed| {
+        let points = Poisson2D::new()
+            .with_dimensions([30.0, 20.0], 5.0)
+            .with_seed(seed)
+            .generate();
+
+        if !points.is_empty() {
+            // FIXME: Need a test to handle empty results; see #34
+            // Test every point against every other point
+            for i in 0..(points.len() - 1) {
+                // Only need to test points later in the list, since we've already tested i against earlier points
+                for j in (i+1)..points.len() {
+                    assert!(5.0 <= distance(points[i], points[j]));
+                }
+            }
+        }
+    });
 }
 
 fn distance(p1: [f64; 2], p2: [f64; 2]) -> f64 {


### PR DESCRIPTION
Replace the faulty "spatial grid" originally implemented to check for points in the "neighborhood" with a k-d tree via the `kiddo` crate. This does sacrifice performance a bit (~5% for a 2D distribution), but was a lot easier to bring in than fixing the grid would have been, which may have come with a performance penalty on its own as well.

Resolves #33 