### PR TITLE
Introduce support for wraparound dimensions

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -52,7 +52,7 @@ where
             // Start somewhere near the middle, but still randomly distributed
             // Fixes #34 by avoiding cases where we start near an edge/corner and happen to only generate
             // samples outside of our boundaries (because we only have ~25% chance of picking one inside)
-            *i = (1.5 - rng.random::<Float>()) * dim / 2.0;
+            *i = (1.5 - rng.random::<Float>()) * dim.magnitude / 2.0;
         }
 
         Iter {
@@ -109,15 +109,48 @@ where
         point
             .iter()
             .zip(self.distribution.dimensions.iter())
-            .all(|(p, d)| *p >= 0. && p < d)
+            .all(|(p, d)| d.wrapping || (*p >= 0. && *p < d.magnitude))
     }
 
     /// Returns true if there is at least one other sample point within `radius` of this point
     fn in_neighborhood(&self, point: Point<N>) -> bool {
-        !self
-            .sampled
-            .within::<SquaredEuclidean>(&point, self.distribution.radius.powi(2))
-            .is_empty()
+        let mut points = vec![point];
+
+        for (index, dim) in self.distribution.dimensions.iter().enumerate() {
+            if dim.wrapping {
+                let current_total = points.len();
+                points.extend_from_within(..current_total);
+
+                for point in &mut points[current_total..] {
+                    if point[index] <= (dim.magnitude / 2.) {
+                        point[index] += dim.magnitude;
+                    } else {
+                        point[index] -= dim.magnitude;
+                    }
+                }
+            }
+        }
+
+        points.into_iter().any(|point| {
+            !self
+                .sampled
+                .within::<SquaredEuclidean>(&point, self.distribution.radius.powi(2))
+                .is_empty()
+        })
+    }
+
+    fn wrap_point(&self, mut point: Point<N>) -> Point<N> {
+        for (value, dimension) in point.iter_mut().zip(self.distribution.dimensions.iter()) {
+            if dimension.wrapping {
+                if *value < 0. {
+                    *value += dimension.magnitude;
+                } else if *value > dimension.magnitude {
+                    *value -= dimension.magnitude;
+                }
+            }
+        }
+
+        point
     }
 }
 
@@ -138,6 +171,8 @@ where
                 // Ensure we've picked a point inside the bounds of our rectangle, and more than `radius`
                 // distance from any other sampled point
                 if self.in_space(point) && !self.in_neighborhood(point) {
+                    let point = self.wrap_point(point);
+
                     // We've got a good one!
                     self.add_point(point);
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -114,7 +114,16 @@ where
 
     /// Returns true if there is at least one other sample point within `radius` of this point
     fn in_neighborhood(&self, point: Point<N>) -> bool {
-        let mut points = vec![point];
+        if !self
+            .sampled
+            .within::<SquaredEuclidean>(&point, self.distribution.radius.powi(2))
+            .is_empty()
+        {
+            return true;
+        }
+
+        let mut points = Vec::with_capacity(N ^ 2);
+        points.push(point);
 
         for (index, dim) in self.distribution.dimensions.iter().enumerate() {
             if dim.wrapping {
@@ -127,16 +136,19 @@ where
                     } else {
                         point[index] -= dim.magnitude;
                     }
+
+                    if !self
+                        .sampled
+                        .within::<SquaredEuclidean>(&point, self.distribution.radius.powi(2))
+                        .is_empty()
+                    {
+                        return true;
+                    }
                 }
             }
         }
 
-        points.into_iter().any(|point| {
-            !self
-                .sampled
-                .within::<SquaredEuclidean>(&point, self.distribution.radius.powi(2))
-                .is_empty()
-        })
+        return false;
     }
 
     fn wrap_point(&self, mut point: Point<N>) -> Point<N> {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -104,7 +104,8 @@ where
 
     /// Returns true if the point is within the bounds of our space.
     ///
-    /// This is true if 0 ≤ point[i] < dimensions[i]
+    /// This is true if 0 ≤ point[i] < dimensions[i].
+    /// Any wrapping dimensions are treateda s always in bounds, and will be sensibly handled by the other logic
     fn in_space(&self, point: Point<N>) -> bool {
         point
             .iter()
@@ -114,6 +115,7 @@ where
 
     /// Returns true if there is at least one other sample point within `radius` of this point
     fn in_neighborhood(&self, point: Point<N>) -> bool {
+        // First, check if we can return early
         if !self
             .sampled
             .within::<SquaredEuclidean>(&point, self.distribution.radius.powi(2))
@@ -121,6 +123,10 @@ where
         {
             return true;
         }
+
+        // If not, we might need to check a few different points depending on any wrapping dimensions
+        // For any wrapping dimension, we want to check the original point and the point with that dimension wrapped.
+        // When there are multiple wrapping dimensions, we essentially need the powerset of all dimensions that are wrapping
 
         let mut points = Vec::with_capacity(N ^ 2);
         points.push(point);
@@ -151,6 +157,11 @@ where
         return false;
     }
 
+    /// Returns the value of a point potentially outside the bounds wrapped back into the bounds
+    ///
+    /// When dimensions are wrapping, we may end up with a valid point up to `2 * radius` outside of the bounds
+    /// of a wrapping dimension. This method ensures that we convert those to thir representations within the bounds
+    /// such that the set of points we return to the user are all normalised
     fn wrap_point(&self, mut point: Point<N>) -> Point<N> {
         for (value, dimension) in point.iter_mut().zip(self.distribution.dimensions.iter()) {
             if dimension.wrapping {
@@ -183,9 +194,8 @@ where
                 // Ensure we've picked a point inside the bounds of our rectangle, and more than `radius`
                 // distance from any other sampled point
                 if self.in_space(point) && !self.in_neighborhood(point) {
-                    let point = self.wrap_point(point);
-
                     // We've got a good one!
+                    let point = self.wrap_point(point);
                     self.add_point(point);
 
                     return Some(point);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -178,12 +178,12 @@ where
             for _ in 0..self.distribution.num_samples {
                 // Generate up to `num_samples` random points between radius and 2*radius from the current point
                 let point = self.generate_random_point(self.active[i]);
+                let point = self.wrap_point(point);
 
                 // Ensure we've picked a point inside the bounds of our rectangle, and more than `radius`
                 // distance from any other sampled point
                 if self.in_space(point) && !self.in_neighborhood(point) {
                     // We've got a good one!
-                    let point = self.wrap_point(point);
                     self.add_point(point);
 
                     return Some(point);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -72,7 +72,31 @@ where
         self.active.push(point);
 
         // Now stash this point in our samples
-        self.sampled.add(&point, 0);
+        // For wrapping to work, we need to add the point itself
+        // as well as wrapped representations of it for each wrapping dimension
+        let mut points = Vec::with_capacity(N ^ 2);
+        points.push((point, 0));
+
+        for (index, dim) in self
+            .distribution
+            .dimensions
+            .iter()
+            .enumerate()
+            .filter(|(_, dim)| dim.wrapping)
+        {
+            let current_total = points.len();
+            points.extend_from_within(..current_total);
+
+            for (point, _) in &mut points[current_total..] {
+                if point[index] <= (dim.magnitude / 2.) {
+                    point[index] += dim.magnitude;
+                } else {
+                    point[index] -= dim.magnitude;
+                }
+            }
+        }
+
+        self.sampled.extend(points);
     }
 
     /// Generate a random point between `radius` and `2 * radius` away from the given point
@@ -105,7 +129,7 @@ where
     /// Returns true if the point is within the bounds of our space.
     ///
     /// This is true if 0 ≤ point[i] < dimensions[i].
-    /// Any wrapping dimensions are treateda s always in bounds, and will be sensibly handled by the other logic
+    /// Any wrapping dimensions are treated as always in bounds, and will be sensibly handled by the other logic
     fn in_space(&self, point: Point<N>) -> bool {
         point
             .iter()
@@ -115,46 +139,10 @@ where
 
     /// Returns true if there is at least one other sample point within `radius` of this point
     fn in_neighborhood(&self, point: Point<N>) -> bool {
-        // First, check if we can return early
-        if !self
+        !self
             .sampled
-            .within::<SquaredEuclidean>(&point, self.distribution.radius.powi(2))
+            .within_unsorted::<SquaredEuclidean>(&point, self.distribution.radius.powi(2))
             .is_empty()
-        {
-            return true;
-        }
-
-        // If not, we might need to check a few different points depending on any wrapping dimensions
-        // For any wrapping dimension, we want to check the original point and the point with that dimension wrapped.
-        // When there are multiple wrapping dimensions, we essentially need the powerset of all dimensions that are wrapping
-
-        let mut points = Vec::with_capacity(N ^ 2);
-        points.push(point);
-
-        for (index, dim) in self.distribution.dimensions.iter().enumerate() {
-            if dim.wrapping {
-                let current_total = points.len();
-                points.extend_from_within(..current_total);
-
-                for point in &mut points[current_total..] {
-                    if point[index] <= (dim.magnitude / 2.) {
-                        point[index] += dim.magnitude;
-                    } else {
-                        point[index] -= dim.magnitude;
-                    }
-
-                    if !self
-                        .sampled
-                        .within::<SquaredEuclidean>(&point, self.distribution.radius.powi(2))
-                        .is_empty()
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-
-        return false;
     }
 
     /// Returns the value of a point potentially outside the bounds wrapped back into the bounds

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ pub(crate) mod inner_types {
 
     /// The floating-point type
     pub(crate) type Float = f32;
+
     /// The default PRNG
     pub(crate) type Rand = rand_xoshiro::Xoshiro128StarStar;
 }
@@ -172,7 +173,10 @@ use inner_types::*;
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "derive_serde", derive(Serialize, Deserialize))]
 pub(crate) struct Dim {
+    /// The size of this dimension
     magnitude: Float,
+
+    /// Whether this dimension wraps around
     wrapping: bool,
 }
 
@@ -275,6 +279,24 @@ where
         self
     }
 
+    /// Specify whether any of the dimensions in this distrubution wrap around
+    ///
+    /// By default, the dimensions are assumed to not wrap. A point close to the edge of a dimension
+    /// (close to 0 or close to that diemensions magnitude as set by [`with_dimensions`][Self::with_dimensions])
+    /// will only check the radius inside the bounds themselves for neighbours. Any portions of the radius
+    /// circle that are outside the bounds will be essentially ignore.
+    ///
+    /// If a diemension is set to wrap, those ignored radius bounds are instead wrapped around to the other end
+    /// of the dimensions extent. As an example, given the following definition:
+    /// ```
+    /// # use fast_poisson::Poisson2D;
+    /// let mut points = Poisson2D::new()
+    ///     .with_dimensions([50.0, 50.0], 10.0)
+    ///     .with_wrapping([true, false]);
+    /// ```
+    /// The points `[1, 20]` and `[49, 20]` would be rejected as too close
+    ///
+    /// See also [`set_wrapping`][Self::set_wrapping].
     #[must_use]
     pub fn with_wrapping(mut self, wrapping: [bool; N]) -> Self {
         self.set_wrapping(wrapping);
@@ -341,6 +363,9 @@ where
         self.radius = radius;
     }
 
+    /// Specify whether any of the dimensions in this distrubution wrap around
+    ///
+    /// For more see [`with_wrapping`][Self::with_wrapping].
     pub fn set_wrapping(&mut self, wrapping: [bool; N]) {
         for (dimension, wrapping) in self.dimensions.iter_mut().zip(wrapping) {
             dimension.wrapping = wrapping;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ pub(crate) mod inner_types {
 
     /// The floating-point type
     pub(crate) type Float = f64;
+
     /// The default PRNG
     pub(crate) type Rand = rand_xoshiro::Xoshiro256StarStar;
 }
@@ -167,6 +168,22 @@ pub(crate) mod inner_types {
     pub(crate) type Rand = rand_xoshiro::Xoshiro128StarStar;
 }
 use inner_types::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "derive_serde", derive(Serialize, Deserialize))]
+pub(crate) struct Dim {
+    magnitude: Float,
+    wrapping: bool,
+}
+
+impl Default for Dim {
+    fn default() -> Self {
+        Self {
+            magnitude: 1.0,
+            wrapping: false,
+        }
+    }
+}
 
 /// Poisson disk distribution in N dimensions
 ///
@@ -203,7 +220,7 @@ where
 {
     /// Dimensions of the box
     #[cfg_attr(feature = "derive_serde", serde(with = "serde_arrays"))]
-    dimensions: [Float; N],
+    dimensions: [Dim; N],
     /// Radius around each point that must remain empty
     radius: Float,
     /// Seed to use for the internal RNG
@@ -254,6 +271,13 @@ where
     #[must_use]
     pub fn with_dimensions(mut self, dimensions: [Float; N], radius: Float) -> Self {
         self.set_dimensions(dimensions, radius);
+
+        self
+    }
+
+    #[must_use]
+    pub fn with_wrapping(mut self, wrapping: [bool; N]) -> Self {
+        self.set_wrapping(wrapping);
 
         self
     }
@@ -310,8 +334,17 @@ where
     ///
     /// For more see [`with_dimensions`][Self::with_dimensions].
     pub fn set_dimensions(&mut self, dimensions: [Float; N], radius: Float) {
-        self.dimensions = dimensions;
+        for (dimension, magnitude) in self.dimensions.iter_mut().zip(dimensions) {
+            dimension.magnitude = magnitude;
+        }
+
         self.radius = radius;
+    }
+
+    pub fn set_wrapping(&mut self, wrapping: [bool; N]) {
+        for (dimension, wrapping) in self.dimensions.iter_mut().zip(wrapping) {
+            dimension.wrapping = wrapping;
+        }
     }
 
     /// Specify the PRNG seed for this distribution
@@ -467,7 +500,7 @@ where
 {
     fn default() -> Self {
         Self {
-            dimensions: [1.0; N],
+            dimensions: [Default::default(); N],
             radius: 0.1,
             seed: None,
             num_samples: 30,

--- a/tests/million_seeds.rs
+++ b/tests/million_seeds.rs
@@ -19,12 +19,19 @@ fn million_seeds() {
 
         let points_defaults = Poisson2D::new().with_seed(seed).generate();
 
+        // Ensure we test all combintations of wrapping with the two dimensions we have here
+        let index = s % 4;
+        let x_wrapping = index == 1 || index == 3;
+        let y_wrapping = index == 2 || index == 3;
+
         let points = Poisson2D::new()
             .with_dimensions([30.0, 20.0], 5.0)
+            .with_wrapping([x_wrapping, y_wrapping])
             .with_seed(seed)
             .generate();
         let points2 = Poisson2D::new()
             .with_dimensions([30.0, 20.0], 5.0)
+            .with_wrapping([x_wrapping, y_wrapping])
             .with_seed(seed)
             .generate();
 


### PR DESCRIPTION
This PR is a draft pass at introducing support for dimensions that wrap around - i.e., treating `0.0` as adjacent to the maximum extent of the dimension, creating cylindrical or toroidal (in a 2D space) distributions.

On no part do I consider this particularly final, but I wanted to raise this as a proposal for feedback on whether you think this is a suitable addition to the API or not. If not, I'm happy to continue with a fork, but I figured I would see about upstreaming changes if I can.

There are definitely some optimisations that could be made here in terms of returning early if there are no wrapping dimensions in places, or the potentially extreme option of having two overloads of the iterator class with one being your original instance if there is no wrapping at all to leave it as unmodified as possible. Having said that, I didn't notice this adding too much, with <5% slowdown when I run the bench on my development M2 Air - of course, this library is named `fast_poisson`, so any slowdown is probably a bad idea!

In addition to this, I do next want to consider thinking about a non-uniform density, something I can see has been discussed in #39. Have you had any further thoughts on that at all? I am leaning towards the `radius_fn` method and that's probably what I'll start experimenting with (though we should potentially have this particular discussion on that issue)

Cheers, and do let me know what you think of this - I'm more than happy to get this into a polished-up state myself if it's something you do indeed want to consider pulling in